### PR TITLE
register .excalidraw extension

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -25,5 +25,14 @@
   "mac": {
     "hardenedRuntime": true,
     "target": "dmg"
-  }
+  },
+  "fileAssociations": [
+    {
+      "ext": "excalidraw",
+      "name": "Excalidraw",
+      "description": "Excalidraw file",
+      "role": "Editor",
+      "mimeType": "application/json"
+    }
+  ]
 }


### PR DESCRIPTION
Related to #28

This registers the `.excalidraw` extension to the App. What is not working is that it directly opens the file contents to the editor. Is there something to open a file inside the editor from outside?