### PR TITLE
External URLs to be opened in the default browser

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import {app, BrowserWindow} from "electron";
+import {app, BrowserWindow, shell} from "electron";
 import * as minimist from "minimist";
 import * as path from "path";
 import * as url from "url";
@@ -27,6 +27,9 @@ function createWindow() {
     mainWindow.webContents.openDevTools({mode: "detach"});
   }
 
+  mainWindow.webContents.on("will-navigate", openExternalURLs);
+  mainWindow.webContents.on("new-window", openExternalURLs);
+
   mainWindow.loadURL(
     url.format({
       pathname: EXCALIDRAW_BUNDLE,
@@ -53,6 +56,14 @@ function createWindow() {
 
     mainWindow.show();
   });
+}
+
+// Open external links in user's default browser instead of webview
+function openExternalURLs(event: Electron.Event, url: string) {
+  if (url.startsWith("http")) {
+    event.preventDefault();
+    shell.openExternal(url);
+  }
 }
 
 app.on("ready", createWindow);


### PR DESCRIPTION
External URL's to be opened in system default browser instead of navigating in the webview or opening a new webview window.

**Why?**
Currently, clicking on the GitHub icon on the top right of the page now opens a new electron webview and navigates to the GitHub repo.